### PR TITLE
Added a `color` setting for progress bars of different colors

### DIFF
--- a/nprogress.css
+++ b/nprogress.css
@@ -22,7 +22,8 @@
   right: 0px;
   width: 100px;
   height: 100%;
-  box-shadow: 0 0 10px #29d, 0 0 5px #29d;
+  box-shadow: 0 0 10px, 0 0 5px;
+  color: #29d;
   opacity: 1.0;
 
   -webkit-transform: rotate(3deg) translate(0px, -4px);

--- a/nprogress.js
+++ b/nprogress.js
@@ -26,7 +26,9 @@
     showSpinner: true,
     barSelector: '[role="bar"]',
     spinnerSelector: '[role="spinner"]',
+    pegSelector: '.peg',
     parent: 'body',
+    color: '',
     template: '<div class="bar" role="bar"><div class="peg"></div></div><div class="spinner" role="spinner"><div class="spinner-icon"></div></div>'
   };
 
@@ -264,15 +266,30 @@
     var bar      = progress.querySelector(Settings.barSelector),
         perc     = fromStart ? '-100' : toBarPerc(NProgress.status || 0),
         parent   = NProgress.getParent(),
-        spinner;
+        spinner  = progress.querySelector(Settings.spinnerSelector),
+        peg      = progress.querySelector(Settings.pegSelector);
 
     css(bar, {
       transition: 'all 0 linear',
       transform: 'translate3d(' + perc + '%,0,0)'
     });
 
+    if (Settings.color) {
+      css(bar, {
+        background: Settings.color
+      });
+
+      css(spinner.querySelector('.spinner-icon'), {
+        'border-top-color': Settings.color,
+        'border-left-color': Settings.color
+      });
+
+      css(peg, {
+        color: Settings.color
+      });
+    }
+
     if (!Settings.showSpinner) {
-      spinner = progress.querySelector(Settings.spinnerSelector);
       spinner && removeElement(spinner);
     }
 


### PR DESCRIPTION
Added a `color` property to `Settings`. This is not used by default as to provide backwards compatibility for users that relied on customizing the CSS file to get a different color.

Changed `nprogress.css` to allow the box shadow color to be set dynamically using [CSS `color`](https://stackoverflow.com/a/10989662/970180) while preserving the `box-shadow` properties.

When `color` is specified, the progress bar instance is colored using inline styles. This is done so that I can have components with dark backgrounds and light progress bars on the same page as light components with dark progress bars.